### PR TITLE
fix typescript-to-lua/language-extensions error

### DIFF
--- a/scripts/assets/tsconfig.json-
+++ b/scripts/assets/tsconfig.json-
@@ -8,7 +8,7 @@
         "sourceMap": true,
         "moduleResolution": "node",
         "rootDir": "src",
-        "types": ["typescript-to-lua/language-extensions", "lua-types/jit"]
+        "types": ["@typescript-to-lua/language-extensions", "lua-types/jit"]
     },
     "tstl": {
         "luaTarget": "JIT"


### PR DESCRIPTION
typescript-to-lua/language-extensions is a separate npm package named "@typescript-to-lua/language-extensions" since 2022-09-04 ([PR](https://github.com/TypeScriptToLua/TypeScriptToLua/pull/1345))

using it without "@" at the front leads to a compilation error "error TS2688: Cannot find type definition file for 'typescript-to-lua/language-extensions'"

![image](https://user-images.githubusercontent.com/28571964/193752621-816b0e20-b631-4c79-99d9-4054e292826c.png)
